### PR TITLE
Added 'origin' property. Renamed FakeInputAutocomplete property.

### DIFF
--- a/src/client/components/FakeInputAutocomplete/FakeInputAutocomplete.DOCUMENTATION.md
+++ b/src/client/components/FakeInputAutocomplete/FakeInputAutocomplete.DOCUMENTATION.md
@@ -13,8 +13,8 @@ FakeInputAutocomplete is a simple clearly looking autocomplete.
 | inputElement | func | Most of all - is a stateless component. Example: `() => <input className="form-group"/>` |
 | onChange | func | Callback fired on input change `(event, inputNewValue) => {}`|
 | onSelect | func | Callback fired on item selection `(event, itemKey) => {}` |
-| ~origin~ TODO | oneOf([ 'top', 'bottom', 'left', 'right' ]) | |
-  maxSuggessionsHeight: PropTypes.number
+| origin | oneOf([ 'top', 'bottom' ]) | Sometimes you want show suggessions popup to top |
+| maxSuggessionsHeight | number | Max suggessions popup height in px |
   
 ### Methods Reference
 
@@ -27,6 +27,7 @@ FakeInputAutocomplete is a simple clearly looking autocomplete.
   onSelect={(event, key) => console.log('Selected item with key: ' + key)}
   onChange={(event, string) => console.log('onChange', string)}
   placeholder="Start typing"
+  origin="bottom"
   items={[
     { key: 'PIM installation', value: 'PIM installation' },
     { key: 'PROV installation', value: 'PROV installation' },

--- a/src/client/components/FakeInputAutocomplete/FakeInputAutocomplete.module.less
+++ b/src/client/components/FakeInputAutocomplete/FakeInputAutocomplete.module.less
@@ -37,6 +37,11 @@
   z-index: 999;
 }
 
+.suggessionsContainerTop {
+  top: auto;
+  bottom: 100%;
+}
+
 .suggessionsContainer:focus {
   outline: none;
 }

--- a/src/client/components/FakeInputAutocomplete/FakeInputAutocomplete.react.js
+++ b/src/client/components/FakeInputAutocomplete/FakeInputAutocomplete.react.js
@@ -63,7 +63,7 @@ class FakeInputAutocomplete extends Component {
       onSelect, // eslint-disable-line no-unused-vars
       inputElement,
       placeholder,
-      // origin, // TODO
+      origin,
       ...restProps
     } = this.props;
     let { value, isFocused } = this.state;
@@ -74,7 +74,7 @@ class FakeInputAutocomplete extends Component {
       placeholder,
       onChange: this.handleInputChange.bind(this),
       ...restProps
-    }
+    };
 
     let input = inputElement ?
       inputReactComponent(inputProps) :
@@ -91,7 +91,10 @@ class FakeInputAutocomplete extends Component {
         }}
       >{interpolatedStyle =>
         <div
-          className={s.suggessionsContainer}
+          className={`
+            ${s.suggessionsContainer}
+            ${origin === 'top' ? s.suggessionsContainerTop : ' '}
+          `}
           style={{
             maxHeight: `${interpolatedStyle.x}px`,
             opacity: interpolatedStyle.y
@@ -133,7 +136,7 @@ FakeInputAutocomplete.propTypes = {
   })),
   onChange: PropTypes.func,
   onSelect: PropTypes.func,
-  // origin: PropTypes.oneOf([ 'top', 'bottom', 'left-top', 'left-bottom', 'right-top', 'right-bottom' ]), // TODO
+  origin: PropTypes.oneOf([ 'top', 'bottom' ]),
   maxSuggessionsHeight: PropTypes.number
 };
 FakeInputAutocomplete.defaultProps = {
@@ -143,6 +146,6 @@ FakeInputAutocomplete.defaultProps = {
   items: [],
   onChange: () => {},
   onSelect: () => {},
-  // origin: 'bottom', // TODO
+  origin: 'top',
   maxSuggessionsHeight: 320
 };


### PR DESCRIPTION
Added 'origin' property with variants - 'top' and 'bottom'.
A common usecase is have possibility to show suggessions popup to top, for example - at the bottom of some form or table.

Also renamed FakeInputAutocomplete property 'inputReactComponent' => 'inputElement'